### PR TITLE
Clean HTML

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension WWW::Wikipedia.
 
+ - Add clean_html option to strip basic HTML tags.
+
 2.01 2013-02-21
 
  - Update test suite due to a change in returned data

--- a/lib/WWW/Wikipedia/Entry.pm
+++ b/lib/WWW/Wikipedia/Entry.pm
@@ -35,7 +35,7 @@ behind the scenes with the correct arguments by WWW::Wikipedia::search().
 =cut
 
 sub new {
-    my ( $class, $raw, $src ) = @_;
+    my ( $class, $raw, $src, %ops ) = @_;
     return if length( $raw ) == 0;
     my $self = bless {
         raw         => $raw,
@@ -55,6 +55,11 @@ sub new {
     # store un-"pretty"-ed version of text
     $self->{ fulltext_basic } = $self->{ fulltext };
     $self->{ text_basic }     = $self->{ text };
+
+    if ($ops{clean_html}) {
+    	$self->{ fulltext } = _clean_html( $self->{ fulltext });
+    	$self->{ text } = _clean_html( $self->{ text });
+    }
 
     $self->{ fulltext } = _pretty( $self->{ fulltext } );
     $self->{ text }     = _pretty( $self->{ text } );
@@ -291,6 +296,14 @@ sub _parse {
             $self->{ fulltext } .= substr( $raw, $self->{ cursor }, 1 );
         }
     }
+}
+
+# future versions might clean tag contents for some specific ones.
+sub _clean_html {
+	my $text = shift;
+	# force first letter so that standalone < might be kept
+	$text =~ s{<[/a-zA-Z!][^>]+>}{}g;
+	return $text;
 }
 
 sub _pretty {

--- a/t/27.clean_html.t
+++ b/t/27.clean_html.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+use WWW::Wikipedia;
+
+# Text::Autoformat has had some bugs which some wikipedia content
+# has been known to trigger. Make sure we cover those bases.
+
+my $wiki = WWW::Wikipedia->new( clean_html => 1 );
+
+my $entry = $wiki->search( 'Inequality_(mathematics)' );
+# test some specific constructs that are not likely to be removed
+# by wikipedia users. This is dangerous...
+like $entry->text, qr/a < b/, "Less than was kept";
+
+$entry = $wiki->search( 'Ampersand' );
+unlike $entry->text, qr/<ref/, "Ref Begin tag was removed";
+unlike $entry->text, qr/<\/ref/, "Ref End tag was removed";
+


### PR DESCRIPTION
Very basic method to remove tags (comments, start tags and end tags).
Their content is preserved for now (unless for comments, of course).
Added a simple test file to test if tags are removed, and if
other less than are preserved. Hopefully this would work for most cases.
In the future a table of tags and behaviours might be relevant (for each
tag, to know if its content should be kept or removed, etc.)
